### PR TITLE
English fixes in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 cov-core
 ========
 
-This is a lib package for use by pytest-cov, nose-cov and nose2-cov.  Unless your developing a
-coverage plugin for a test framework then you probably want one of those.
+This is a lib package for use by pytest-cov, nose-cov and nose2-cov.  Unless you're developing a
+coverage plugin for a test framework, you probably want one of those.


### PR DESCRIPTION
Was https://bitbucket.org/memedough/cov-core/pull-request/4/english-fixes-in-readme
