### PR TITLE
allow for cov_source=None

### DIFF
--- a/cov_core.py
+++ b/cov_core.py
@@ -43,12 +43,15 @@ class CovController(object):
         self.node_descs = set()
         self.failed_slaves = []
         self.topdir = os.getcwd()
-        self.cov_data_file = '.coverage'
+        self.cov_data_file = os.path.join(self.topdir, '.coverage')
 
     def set_env(self):
         """Put info about coverage into the env so that subprocesses can activate coverage."""
 
-        os.environ['COV_CORE_SOURCE'] = UNIQUE_SEP.join(self.cov_source)
+        if self.cov_source is None:
+            os.environ['COV_CORE_SOURCE'] = 'None'
+        else:
+            os.environ['COV_CORE_SOURCE'] = UNIQUE_SEP.join(self.cov_source)
         os.environ['COV_CORE_DATA_FILE'] = self.cov_data_file
         os.environ['COV_CORE_CONFIG'] = self.cov_config
 

--- a/cov_core_init.py
+++ b/cov_core_init.py
@@ -41,7 +41,10 @@ def init():
             import coverage
 
             # Determine all source roots.
-            cov_source = cov_source.split(UNIQUE_SEP)
+            if cov_source == 'None':
+                cov_source = None
+            else:
+                cov_source = cov_source.split(UNIQUE_SEP)
 
             # Produce a unique suffix for this process in the same
             # manner as coverage.


### PR DESCRIPTION
`None` is a legitimate and useful value of cov_source, which means use the default value of coveragepy.
This results in measuring coverage for everything or (more importantly) the configured run.source in coveragerc.
