### PR TITLE
allow for cov_source=None

### DIFF
--- a/cov_core.py
+++ b/cov_core.py
@@ -49,7 +49,7 @@ class CovController(object):
         """Put info about coverage into the env so that subprocesses can activate coverage."""
 
         if self.cov_source is None:
-            os.environ['COV_CORE_SOURCE'] = 'None'
+            os.environ['COV_CORE_SOURCE'] = ''
         else:
             os.environ['COV_CORE_SOURCE'] = UNIQUE_SEP.join(self.cov_source)
         os.environ['COV_CORE_DATA_FILE'] = self.cov_data_file

--- a/cov_core_init.py
+++ b/cov_core_init.py
@@ -33,7 +33,7 @@ def init():
         cov_source = os.environ.get('COV_CORE_SOURCE')
         cov_data_file = os.environ.get('COV_CORE_DATA_FILE')
         cov_config = os.environ.get('COV_CORE_CONFIG')
-        if cov_source and cov_data_file and cov_config:
+        if cov_data_file and cov_config:
 
             # Import what we need to activate coverage.
             import socket
@@ -41,7 +41,7 @@ def init():
             import coverage
 
             # Determine all source roots.
-            if cov_source == 'None':
+            if cov_source == '':
                 cov_source = None
             else:
                 cov_source = cov_source.split(UNIQUE_SEP)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ PTH_FILE_NAME = 'init_cov_core.pth'
 # The line in the path file must begin with "import"
 # so that site.py will exec it.
 PTH_FILE = '''\
-import os; os.environ.get('COV_CORE_SOURCE') and __import__('cov_core_init').init()
+import os; 'COV_CORE_SOURCE' in os.environ and __import__('cov_core_init').init()
 '''
 
 PTH_FILE_FAILURE = '''


### PR DESCRIPTION
None is a legitimate and useful value of cov_source, which means use the default value of coveragepy.
This results in measuring coverage for everything or (more importantly) the configured run.source in coveragerc.

This supersedes #5  (I changed the branch name, for my own sanity)
