### PR TITLE
allow for subprocesses starting with different $PWD

### DIFF
--- a/cov_core.py
+++ b/cov_core.py
@@ -43,7 +43,7 @@ class CovController(object):
         self.node_descs = set()
         self.failed_slaves = []
         self.topdir = os.getcwd()
-        self.cov_data_file = '.coverage'
+        self.cov_data_file = os.path.join(self.topdir, '.coverage')
 
     def set_env(self):
         """Put info about coverage into the env so that subprocesses can activate coverage."""


### PR DESCRIPTION
Currently pytest-cov drops some coverage on the floor if a python subprocess is started from a different $PWD.

This simple change fixes that problem; pin down an absolute path as early as possible.
I've checked that this works well under both centralized and xdist mode.
