### PR TITLE
pip uninstall now correctly removes the pth file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ include LICENSE.txt
 include setup.py
 include cov_core.py
 include cov_core_init.py
+include init_cov_core.pth

--- a/init_cov_core.pth
+++ b/init_cov_core.pth
@@ -1,0 +1,1 @@
+import os; 'COV_CORE_SOURCE' in os.environ and __import__('cov_core_init').init()

--- a/python_lib.py
+++ b/python_lib.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+from distutils.sysconfig import get_python_lib
+import os, sys
+
+python_lib = os.path.relpath(get_python_lib(), sys.prefix)
+
+if __name__ == '__main__':
+    print python_lib

--- a/setup.py
+++ b/setup.py
@@ -2,23 +2,12 @@ import setuptools
 import sys
 import os
 
+from python_lib import python_lib
+
 # The name of the path file must appear after easy-install.pth so that
 # cov_core has been added to the sys.path and cov_core_init can be
 # imported.
 PTH_FILE_NAME = 'init_cov_core.pth'
-
-# The line in the path file must begin with "import"
-# so that site.py will exec it.
-PTH_FILE = '''\
-import os; 'COV_CORE_SOURCE' in os.environ and __import__('cov_core_init').init()
-'''
-
-PTH_FILE_FAILURE = '''
-Subprocesses WILL NOT have coverage collected.
-
-To measure subprocesses put the following in a pth file called %s:
-%s
-''' % (PTH_FILE_NAME, PTH_FILE)
 
 setuptools.setup(name='cov-core',
                  version='1.15.0',
@@ -30,6 +19,7 @@ setuptools.setup(name='cov-core',
                  url='https://github.com/schlamar/cov-core',
                  py_modules=['cov_core',
                              'cov_core_init'],
+                 data_files=[(python_lib, [PTH_FILE_NAME])],
                  install_requires=['coverage>=3.6'],
                  license='MIT License',
                  zip_safe=False,
@@ -46,25 +36,3 @@ setuptools.setup(name='cov-core',
                               'Programming Language :: Python :: 3.0',
                               'Programming Language :: Python :: 3.1',
                               'Topic :: Software Development :: Testing'])
-
-if sys.argv[1] in ('install', 'develop'):
-    for path in sys.path:
-        if (path.endswith('site-packages')) or (path.endswith('dist-packages')
-                                                and 'local' in path):
-            path = os.path.join(path, PTH_FILE_NAME)
-            try:
-                pth_file = open(path, 'w')
-                pth_file.write(PTH_FILE)
-                pth_file.close()
-                sys.stdout.write('\nWrote pth file for subprocess '
-                                 'measurement to %s\n' % path)
-                break
-            except Exception:
-                sys.stdout.write('\nFailed to write pth file for subprocess '
-                                 'measurement to %s\n' % path)
-                sys.stdout.write(PTH_FILE_FAILURE)
-                break
-    else:
-        sys.stdout.write('\nFailed to find site-packages or dist-packages '
-                         'dir to put pth file in.\n')
-        sys.stdout.write(PTH_FILE_FAILURE)


### PR DESCRIPTION
I've been using this exact strategy in one of our own (private) packages for ~8 months now, with no issues.

As a positive side effect, this package can now be wheel'd correctly.
