### PR TITLE
Allow import to fail, a `.pth` file is not a good place to raise exceptions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,16 @@ PTH_FILE_NAME = 'init_cov_core.pth'
 # The line in the path file must begin with "import"
 # so that site.py will exec it.
 PTH_FILE = '''\
-import os; 'COV_CORE_SOURCE' in os.environ and __import__('cov_core_init').init()
+import os; exec(%r)
+''' % '''
+if 'COV_CORE_SOURCE' in os.environ:
+    try:
+        import cov_core_init
+        cov_core_init.init()
+    except ImportError:
+        pass
 '''
+
 
 PTH_FILE_FAILURE = '''
 Subprocesses WILL NOT have coverage collected.


### PR DESCRIPTION
Example: coverage package is not installed.

Fixes https://github.com/pypa/pip/issues/2260.
