### PR TITLE
Env to change output location

### DIFF
--- a/cov_core.py
+++ b/cov_core.py
@@ -43,7 +43,7 @@ class CovController(object):
         self.node_descs = set()
         self.failed_slaves = []
         self.topdir = os.getcwd()
-        self.cov_data_file = '.coverage'
+        self.cov_data_file = os.environ.get('COV_OUTPUT_FILE',None)
 
     def set_env(self):
         """Put info about coverage into the env so that subprocesses can activate coverage."""


### PR DESCRIPTION
The working directory is not always a good place to put output files.   Can't use this plugin without a patch like this.